### PR TITLE
allow external mqtt

### DIFF
--- a/BeemEnergyAddon/BeemClient/main.go
+++ b/BeemEnergyAddon/BeemClient/main.go
@@ -55,8 +55,6 @@ func main() {
 	err := getMQTTInfo(&config)
 	if err != nil {
 		slog.Error("error retrieving MQTT info", "error", err)
-		os.Exit(1)
-
 	}
 
 	// Load config from /data/options.json if it exists

--- a/BeemEnergyAddon/config.yaml
+++ b/BeemEnergyAddon/config.yaml
@@ -3,7 +3,7 @@ url: "https://github.com/funkolab/BeemEnergy"
 description: "Connect your Beem Energy Solar Panel to Home Assistant ⚡️"
 services:
   - "mqtt:want"
-version: "0.2.0"
+version: "0.2.1"
 homeassistant_api: true
 image: "ghcr.io/funkolab/beemenergy"
 slug: "beem_energy"


### PR DESCRIPTION
This pull request includes minor updates to error handling and versioning for the `BeemEnergyAddon` project.

### Error Handling Improvement:
* [`BeemEnergyAddon/BeemClient/main.go`](diffhunk://#diff-110546d3c45991d077fe842f1c0f560159af374ec3b89a2cf6b44d7ac446b137L58-L59): Removed the `os.Exit(1)` call after logging an error in the `getMQTTInfo` function, potentially allowing for more graceful error handling or recovery.

### Version Update:
* [`BeemEnergyAddon/config.yaml`](diffhunk://#diff-aa09353ce6c4763eb863b40c628ce87e17fa98a11a0cf9b9b414dd543cef97ebL6-R6): Updated the version from `0.2.0` to `0.2.1`, indicating a minor update to the addon.